### PR TITLE
Initialize `$lazy_sources` to avoid PHP notice.

### DIFF
--- a/src/Dependencies/RocketLazyload/Image.php
+++ b/src/Dependencies/RocketLazyload/Image.php
@@ -256,10 +256,10 @@ class Image {
 				continue;
 			}
 
+			$lazy_sources = 0;
+
 			if ( preg_match_all( '#<source(?<atts>\s.+)>#iUs', $picture['sources'], $sources, PREG_SET_ORDER ) ) {
 				$sources = array_unique( $sources, SORT_REGULAR );
-
-				$lazy_sources = 0;
 
 				foreach ( $sources as $source ) {
 					$lazyload_srcset = preg_replace( '/([\s"\'])srcset/i', '\1data-lazy-srcset', $source[0] );


### PR DESCRIPTION
`PHP Notice:  Undefined variable: lazy_sources in /var/www/wp-content/plugins/rocket-lazy-load/src/Dependencies/RocketLazyload/Image.php on line 273`