### PR TITLE
Tested up to: 6.5 (major versions only for this field)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wp_rocket, wp_media
 Tags: lazyload, lazy load, images, iframes, thumbnail, thumbnails, smiley, smilies, avatar, gravatar, youtube
 Requires at least: 4.9
-Tested up to: 6.5.5
+Tested up to: 6.5
 Requires PHP: 7.3
 Stable tag: 2.3.8
 Tags: lazy load, lazy loading, defer offscreen images, lazy load plugin, lazy load images, image lazy loading, iframe lazy load, video lazy load


### PR DESCRIPTION
At the request of Remy:

The tested up to version should match with major version, not minor.

> This field ignores minor versions, as plugins shouldn’t break with a minor update. This means a plugin only need to define the major version it is tested against and the WordPress.org plugin directory will automatically add the minor version.