### PR TITLE
Add PHPStan, workflow and fix errors

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,15 @@
+name: PHPStan
+
+on:
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancel all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpstan:
+    uses: wp-media/workflows/.github/workflows/phpstan.yml@main

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 		"sort-packages": true,
 		"allow-plugins": {
 			"composer/installers": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"phpstan/extension-installer": true
 		}
 	},
 	"support": {
@@ -51,7 +52,9 @@
 		"coenjacobs/mozart": "^0.7.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.0",
+		"phpstan/extension-installer": "^1.4",
 		"phpunit/phpunit": "^8 || ^9",
+		"szepeviktor/phpstan-wordpress": "^2.0",
 		"wp-coding-standards/wpcs": "^3.0",
 		"wp-media/phpunit": "^3.0"
 	},
@@ -71,6 +74,7 @@
 	"scripts": {
 		"phpcs": "vendor/bin/phpcs",
 		"phpcbf": "vendor/bin/phpcbf",
+		"phpstan": "vendor/bin/phpstan analyze --memory-limit=2G",
         "test-unit":"\"vendor/bin/phpunit\" --testsuite unit --colors=always",
 		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist",
 		"post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e28b56b7fe16bb028f5b413633279a7",
+    "content-hash": "6c0f4db06412f4cd133605a88b668a29",
     "packages": [
         {
             "name": "composer/installers",
@@ -1391,6 +1391,58 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
+            },
+            "time": "2026-02-03T19:29:21+00:00"
+        },
+        {
             "name": "phpcompatibility/php-compatibility",
             "version": "9.3.5",
             "source": {
@@ -1777,6 +1829,107 @@
                 }
             ],
             "time": "2025-12-08T14:27:58+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.50",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
+                "reference": "d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-17T13:10:32+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4201,6 +4354,69 @@
                 }
             ],
             "time": "2026-02-08T20:44:54+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "php-stubs/wordpress-stubs": "^6.6.2",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "composer/semver": "^3.4",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.3"
+            },
+            "time": "2025-09-14T02:58:22+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/includes/RocketLazyloadRequirementsCheck.php
+++ b/includes/RocketLazyloadRequirementsCheck.php
@@ -88,8 +88,10 @@ class Rocket_Lazyload_Requirements_Check {
 
 	/**
 	 * Displays a notice if requirements are not met.
+	 *
+	 * @return void
 	 */
-	public function notice() {
+	public function notice(): void {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,11 @@
+includes:
+    - phar://phpstan.phar/conf/bleedingEdge.neon
+parameters:
+    level: 5
+    inferPrivatePropertyTypeFromConstructor: true
+    paths:
+        - includes/
+        - src/
+        - rocket-lazy-load.php
+    excludePaths:
+        - src/Dependencies/

--- a/src/Admin/AdminPage.php
+++ b/src/Admin/AdminPage.php
@@ -101,17 +101,35 @@ class AdminPage {
 	 * @since 2.0
 	 */
 	public function render_page() {
-		$this->render_template( 'admin-page' );
+		$data = [
+			'images'  => [
+				'label' => __( 'Images', 'rocket-lazy-load' ),
+				'value' => $this->options->get( 'images' ),
+			],
+			'iframes' => [
+				'label' => __( 'Iframes &amp; Videos', 'rocket-lazy-load' ),
+				'value' => $this->options->get( 'iframes' ),
+			],
+			'youtube' => [
+				'label' => __( 'Replace Youtube videos by thumbnail', 'rocket-lazy-load' ),
+				'value' => $this->options->get( 'youtube' ),
+			],
+		];
+
+		$this->render_template( 'admin-page', $data );
 	}
 
 	/**
 	 * Renders the given template if it's readable.
 	 *
-	 * @param string $template Template name.
-	 *
 	 * @since 2.0
+	 *
+	 * @param string $template Template name.
+	 * @param array  $data     Data to pass to the template.
+	 *
+	 * @return void
 	 */
-	protected function render_template( $template ) {
+	protected function render_template( $template, $data = [] ): void {
 		$template_path = $this->template_path . $template . '.php';
 
 		if ( ! is_readable( $template_path ) ) {

--- a/src/Admin/AdminPage.php
+++ b/src/Admin/AdminPage.php
@@ -129,7 +129,7 @@ class AdminPage {
 	 *
 	 * @return void
 	 */
-	protected function render_template( $template, $data = [] ): void {
+	protected function render_template( $template, $data = [] ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$template_path = $this->template_path . $template . '.php';
 
 		if ( ! is_readable( $template_path ) ) {

--- a/src/Admin/AdminPage.php
+++ b/src/Admin/AdminPage.php
@@ -129,7 +129,7 @@ class AdminPage {
 	 *
 	 * @return void
 	 */
-	protected function render_template( $template, $data = [] ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	protected function render_template( $template, array $data = [] ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$template_path = $this->template_path . $template . '.php';
 
 		if ( ! is_readable( $template_path ) ) {

--- a/src/Admin/ImagifyNotice.php
+++ b/src/Admin/ImagifyNotice.php
@@ -37,8 +37,10 @@ class ImagifyNotice {
 	 * @since 2.0
 	 *
 	 * @param string $template Template name.
+	 *
+	 * @return void
 	 */
-	protected function render_template( $template ) {
+	protected function render_template( $template ): void {
 		$template_path = $this->template_path . $template . '.php';
 
 		if ( ! is_readable( $template_path ) ) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -32,14 +32,14 @@ class Plugin {
 	/**
 	 * Array of service providers
 	 *
-	 * @var array<ServiceProviderInterface>
+	 * @var array<class-string<ServiceProviderInterface>>
 	 */
 	private $providers;
 
 	/**
 	 * Constructor
 	 *
-	 * @param array $providers Array of service providers.
+	 * @param array<class-string<ServiceProviderInterface>> $providers Array of service providers.
 	 */
 	public function __construct( array $providers ) {
 		$this->providers = $providers;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,6 +7,7 @@ use RocketLazyLoadPlugin\Dependencies\League\Container\Argument\Literal\ArrayArg
 use RocketLazyLoadPlugin\Dependencies\League\Container\Argument\Literal\StringArgument;
 use RocketLazyLoadPlugin\Dependencies\League\Container\Container;
 use RocketLazyLoadPlugin\Dependencies\League\Container\ServiceProvider\ServiceProviderInterface;
+use RocketLazyLoadPlugin\ServiceProvider\ServiceProviderSubscribersInterface;
 use WPMedia\EventManager\EventManager;
 use WPMedia\EventManager\PluginApiManager;
 use WPMedia\EventManager\SubscriberInterface;
@@ -26,12 +27,12 @@ class Plugin {
 	 *
 	 * @var bool
 	 */
-	private $loaded;
+	private $loaded = false;
 
 	/**
 	 * Array of service providers
 	 *
-	 * @var array
+	 * @var array<ServiceProviderInterface>
 	 */
 	private $providers;
 
@@ -88,18 +89,20 @@ class Plugin {
 
 			$this->container->addServiceProvider( $provider_instance );
 
-			$this->load_subscribers( $provider_instance );
+			if ( $provider_instance instanceof ServiceProviderSubscribersInterface ) {
+				$this->load_subscribers( $provider_instance );
+			}
 		}
 	}
 
 	/**
 	 * Load list of event subscribers from service provider.
 	 *
-	 * @param ServiceProviderInterface $service_provider Instance of service provider.
+	 * @param ServiceProviderSubscribersInterface $service_provider Instance of service provider.
 	 *
 	 * @return void
 	 */
-	private function load_subscribers( ServiceProviderInterface $service_provider ) {
+	private function load_subscribers( ServiceProviderSubscribersInterface $service_provider ) {
 		if ( empty( $service_provider->get_subscribers() ) ) {
 			return;
 		}

--- a/src/ServiceProvider/AdminServiceProvider.php
+++ b/src/ServiceProvider/AdminServiceProvider.php
@@ -8,7 +8,7 @@ use RocketLazyLoadPlugin\Dependencies\League\Container\ServiceProvider\AbstractS
 use RocketLazyLoadPlugin\Subscriber\AdminPageSubscriber;
 use WPMedia\Options\OptionArray;
 
-class AdminServiceProvider extends AbstractServiceProvider {
+class AdminServiceProvider extends AbstractServiceProvider implements ServiceProviderSubscribersInterface {
 	/**
 	 * Services provided by this provider
 	 *
@@ -51,7 +51,7 @@ class AdminServiceProvider extends AbstractServiceProvider {
 			->addArguments(
 				[
 					OptionArray::class,
-					$this->container->get( 'template_path' ),
+					$this->getContainer()->get( 'template_path' ),
 				]
 			);
 
@@ -59,7 +59,7 @@ class AdminServiceProvider extends AbstractServiceProvider {
 			->addArguments(
 				[
 					AdminPage::class,
-					$this->container->get( 'plugin_basename' ),
+					$this->getContainer()->get( 'plugin_basename' ),
 				]
 			);
 	}

--- a/src/ServiceProvider/ImagifyNoticeServiceProvider.php
+++ b/src/ServiceProvider/ImagifyNoticeServiceProvider.php
@@ -7,7 +7,7 @@ use RocketLazyLoadPlugin\Dependencies\League\Container\ServiceProvider\AbstractS
 use RocketLazyLoadPlugin\Admin\ImagifyNotice;
 use RocketLazyLoadPlugin\Subscriber\ImagifyNoticeSubscriber;
 
-class ImagifyNoticeServiceProvider extends AbstractServiceProvider {
+class ImagifyNoticeServiceProvider extends AbstractServiceProvider implements ServiceProviderSubscribersInterface {
 	/**
 	 * Services provided by this provider
 	 *
@@ -21,7 +21,7 @@ class ImagifyNoticeServiceProvider extends AbstractServiceProvider {
 	/**
 	 * Subscribers provided by this provider
 	 *
-	 * @var array
+	 * @return array
 	 */
 	public function get_subscribers(): array {
 		return [
@@ -47,7 +47,7 @@ class ImagifyNoticeServiceProvider extends AbstractServiceProvider {
 	 */
 	public function register(): void {
 		$this->getContainer()->add( ImagifyNotice::class )
-			->addArgument( $this->container->get( 'template_path' ) );
+			->addArgument( $this->getContainer()->get( 'template_path' ) );
 
 		$this->getContainer()->addShared( ImagifyNoticeSubscriber::class )
 			->addArgument( ImagifyNotice::class );

--- a/src/ServiceProvider/LazyloadServiceProvider.php
+++ b/src/ServiceProvider/LazyloadServiceProvider.php
@@ -11,7 +11,7 @@ use RocketLazyLoadPlugin\Subscriber\LazyloadSubscriber;
 use RocketLazyLoadPlugin\Subscriber\ThirdParty\AMPSubscriber;
 use WPMedia\Options\OptionArray;
 
-class LazyloadServiceProvider extends AbstractServiceProvider {
+class LazyloadServiceProvider extends AbstractServiceProvider implements ServiceProviderSubscribersInterface {
 	/**
 	 * Services provided by this provider
 	 *
@@ -28,7 +28,7 @@ class LazyloadServiceProvider extends AbstractServiceProvider {
 	/**
 	 * Subscribers provided by this provider
 	 *
-	 * @var array
+	 * @return array
 	 */
 	public function get_subscribers(): array {
 		return [

--- a/src/ServiceProvider/ServiceProviderSubscribersInterface.php
+++ b/src/ServiceProvider/ServiceProviderSubscribersInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace RocketLazyLoadPlugin\ServiceProvider;
+
+interface ServiceProviderSubscribersInterface {
+    /**
+     * Subscribers provided by this provider
+     *
+     * @return array
+     */
+    public function get_subscribers(): array;
+}

--- a/src/ServiceProvider/ServiceProviderSubscribersInterface.php
+++ b/src/ServiceProvider/ServiceProviderSubscribersInterface.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace RocketLazyLoadPlugin\ServiceProvider;
 
 interface ServiceProviderSubscribersInterface {
-    /**
-     * Subscribers provided by this provider
-     *
-     * @return array
-     */
-    public function get_subscribers(): array;
+	/**
+	 * Subscribers provided by this provider
+	 *
+	 * @return array
+	 */
+	public function get_subscribers(): array;
 }

--- a/src/Subscriber/AdminPageSubscriber.php
+++ b/src/Subscriber/AdminPageSubscriber.php
@@ -99,15 +99,17 @@ class AdminPageSubscriber implements SubscriberInterface {
 	/**
 	 * Enqueue the css for the option page
 	 *
+	 * @since 2.0
+	 *
 	 * @param string $hook_suffix Current page hook.
 	 *
-	 * @since 2.0
+	 * @return void
 	 */
-	public function enqueue_admin_style( $hook_suffix ) {
+	public function enqueue_admin_style( $hook_suffix ): void {
 		if ( 'settings_page_rocket_lazyload' !== $hook_suffix ) {
 			return;
 		}
 
-		wp_enqueue_style( 'rocket-lazyload', Config::get( 'assets_url' ) . 'css/admin.css', null, Config::get( 'version' ) );
+		wp_enqueue_style( 'rocket-lazyload', Config::get( 'assets_url' ) . 'css/admin.css', [], Config::get( 'version' ) );
 	}
 }

--- a/src/Subscriber/ImagifyNoticeSubscriber.php
+++ b/src/Subscriber/ImagifyNoticeSubscriber.php
@@ -120,7 +120,13 @@ class ImagifyNoticeSubscriber implements SubscriberInterface {
 		if ( defined( 'DOING_AJAX' ) ) {
 			wp_send_json( [ 'error' => 0 ] );
 		} else {
-			wp_safe_redirect( esc_url_raw( wp_get_referer() ) );
+			$referer = wp_get_referer();
+
+			if ( false === $referer ) {
+				$referer = admin_url( 'options-general.php?page=rocket_lazyload' );
+			}
+
+			wp_safe_redirect( esc_url_raw( $referer ) );
 			die();
 		}
 	}

--- a/src/Subscriber/LazyloadSubscriber.php
+++ b/src/Subscriber/LazyloadSubscriber.php
@@ -106,7 +106,6 @@ class LazyloadSubscriber implements SubscriberInterface {
 		$script_args = [
 			'base_url' => Config::get( 'assets_url' ) . 'js/',
 			'version'  => '16.1',
-			'polyfill' => false,
 		];
 
 		$inline_args = [
@@ -121,7 +120,6 @@ class LazyloadSubscriber implements SubscriberInterface {
 
 		if ( $this->options->get( 'images' ) || $this->options->get( 'iframes' ) ) {
 			if ( $this->is_native_images() ) {
-				$inline_args['elements']            = isset( $inline_args['elements'] ) ? $inline_args['elements'] : [];
 				$inline_args['elements']['loading'] = '[loading=lazy]';
 			}
 		}
@@ -176,9 +174,10 @@ class LazyloadSubscriber implements SubscriberInterface {
 		$thumbnail_resolution = apply_filters( 'rocket_lazyload_youtube_thumbnail_resolution', 'hqdefault' );
 
 		$this->assets->insertYoutubeThumbnailScript(
+			// @phpstan-ignore-next-line
 			[
 				'resolution' => $thumbnail_resolution,
-				'lazy_image' => (bool) $this->options->get( 'images' ),
+				'lazy_image' => (bool) $this->options->get( 'images', false ),
 			]
 		);
 	}
@@ -372,7 +371,13 @@ class LazyloadSubscriber implements SubscriberInterface {
 	 * @return string
 	 */
 	private function ignoreScripts( $html ) {
-		return preg_replace( '/<script\b(?:[^>]*)>(?:.+)?<\/script>/Umsi', '', $html );
+		$replaced = preg_replace( '/<script\b(?:[^>]*)>(?:.+)?<\/script>/Umsi', '', $html );
+
+		if ( null === $replaced ) {
+			return $html;
+		}
+
+		return $replaced;
 	}
 
 	/**
@@ -383,7 +388,13 @@ class LazyloadSubscriber implements SubscriberInterface {
 	 * @return string
 	 */
 	private function ignoreNoscripts( $html ) {
-		return preg_replace( '#<noscript>(?:.+)</noscript>#Umsi', '', $html );
+		$replaced = preg_replace( '#<noscript>(?:.+)</noscript>#Umsi', '', $html );
+
+		if ( null === $replaced ) {
+			return $html;
+		}
+
+		return $replaced;
 	}
 
 	/**

--- a/views/admin-page.php
+++ b/views/admin-page.php
@@ -4,21 +4,6 @@ use RocketLazyLoadPlugin\Config;
 
 defined( 'ABSPATH' ) || exit;
 
-$rll_options = [
-	'images'  => [
-		'label' => __( 'Images', 'rocket-lazy-load' ),
-		'value' => $this->options->get( 'images' ),
-	],
-	'iframes' => [
-		'label' => __( 'Iframes &amp; Videos', 'rocket-lazy-load' ),
-		'value' => $this->options->get( 'iframes' ),
-	],
-	'youtube' => [
-		'label' => __( 'Replace Youtube videos by thumbnail', 'rocket-lazy-load' ),
-		'value' => $this->options->get( 'youtube' ),
-	],
-];
-
 ?>
 <div class="wrap rocket-lazyload-settings">
 	<h1 class="screen-reader-text"><?php echo esc_html( get_admin_page_title() ); ?></h1>
@@ -45,7 +30,7 @@ $rll_options = [
 				<p><?php esc_html_e( 'This mechanism reduces the number of HTTP requests and improves the loading time.', 'rocket-lazy-load' ); ?></p>
 				<ul class="rocket-lazyload-options">
 					<?php
-					foreach ( $rll_options as $rll_slug => $rll_infos ) :
+					foreach ( $data as $rll_slug => $rll_infos ) :
 						?>
 					<li class="rocket-lazyload-option">
 						<input type="checkbox" value="1" id="lazyload-<?php echo esc_attr( $rll_slug ); ?>" name="rocket_lazyload_options[<?php echo esc_attr( $rll_slug ); ?>]" <?php checked( $rll_infos['value'] ?? 0, 1 ); ?> aria-labelledby="describe-lazyload-<?php echo esc_attr( $rll_slug ); ?>">


### PR DESCRIPTION
# Description

Add PHPStan for WordPress, Github workflow and fix errors reported

## Type of change

- [x] Chore

## Technical description

### Documentation

Adds PHPStan static analysis to the plugin (Composer deps + config + GitHub Actions workflow) and applies a set of code adjustments/type-safety fixes to satisfy reported issues.

**Changes:**
- Add PHPStan tooling (Composer dev deps, `phpstan.neon.dist`, and a reusable-workflow GH Action).
- Refactor admin-page option data passing (build data in `AdminPage` and consume it in the view).
- Apply various PHPStan-driven fixes (typed returns/params, safer redirects, safer `preg_replace` handling, container access cleanup).

### New dependencies

```
"phpstan/extension-installer": "^1.4",
"szepeviktor/phpstan-wordpress": "^2.0",
```