### PR TITLE
Add wordpress/scripts for formatting and linting

### DIFF
--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -1,24 +1,24 @@
 name: Deploy to WordPress.org
 on:
-  push:
-    tags:
-    - "*"
+    push:
+        tags:
+            - '*'
 jobs:
-  tag:
-    name: New tag
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: regular build
-      run: composer install --ignore-platform-reqs
-    - name: build without dev
-      run: composer install --no-dev --no-scripts --ignore-platform-reqs
-    - name: remove composer/installers
-      run: composer remove composer/installers --update-no-dev --no-scripts --ignore-platform-reqs
-    - name: optimize autoloader
-      run: composer dumpautoload -o
-    - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@master
-      env:
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+    tag:
+        name: New tag
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: regular build
+              run: composer install --ignore-platform-reqs
+            - name: build without dev
+              run: composer install --no-dev --no-scripts --ignore-platform-reqs
+            - name: remove composer/installers
+              run: composer remove composer/installers --update-no-dev --no-scripts --ignore-platform-reqs
+            - name: optimize autoloader
+              run: composer dumpautoload -o
+            - name: WordPress Plugin Deploy
+              uses: 10up/action-wordpress-plugin-deploy@master
+              env:
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -8,7 +8,7 @@ jobs:
         name: New tag
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v4
             - name: regular build
               run: composer install --ignore-platform-reqs
             - name: build without dev

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,15 +1,15 @@
 name: PHP CodeSniffer
 
 on:
-  pull_request:
-  # Allow manually triggering the workflow.
-  workflow_dispatch:
+    pull_request:
+    # Allow manually triggering the workflow.
+    workflow_dispatch:
 
 # Cancel all previous workflow runs for the same branch that have not yet completed.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  phpcs:
-    uses: wp-media/workflows/.github/workflows/phpcs.yml@main
+    phpcs:
+        uses: wp-media/workflows/.github/workflows/phpcs.yml@main

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,15 +1,15 @@
 name: PHPStan
 
 on:
-  pull_request:
-  # Allow manually triggering the workflow.
-  workflow_dispatch:
+    pull_request:
+    # Allow manually triggering the workflow.
+    workflow_dispatch:
 
 # Cancel all previous workflow runs for the same branch that have not yet completed.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  phpstan:
-    uses: wp-media/workflows/.github/workflows/phpstan.yml@main
+    phpstan:
+        uses: wp-media/workflows/.github/workflows/phpstan.yml@main

--- a/.github/workflows/phpunit-legacy.yml
+++ b/.github/workflows/phpunit-legacy.yml
@@ -1,14 +1,14 @@
 name: PHPUnit Tests - Legacy
 
 on:
-  pull_request:
-  # Allow manually triggering the workflow.
-  workflow_dispatch:
+    pull_request:
+    # Allow manually triggering the workflow.
+    workflow_dispatch:
 
 # Cancel all previous workflow runs for the same branch that have not yet completed.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
     setup:
@@ -22,8 +22,8 @@ jobs:
         name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }}
 
         env:
-            WP_TESTS_DIR: "/tmp/tests/phpunit"
-            WP_CORE_DIR: "/tmp/wordpress-develop"
+            WP_TESTS_DIR: '/tmp/tests/phpunit'
+            WP_CORE_DIR: '/tmp/wordpress-develop'
 
         steps:
             - name: Checkout
@@ -33,7 +33,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-versions }}
-                  coverage: none  # XDebug can be enabled here 'coverage: xdebug'
+                  coverage: none # XDebug can be enabled here 'coverage: xdebug'
                   tools: composer:v2, phpunit
 
             - name: Install SVN
@@ -49,7 +49,7 @@ jobs:
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             - name: Install Composer dependencies
-              uses: "ramsey/composer-install@v3"
+              uses: 'ramsey/composer-install@v3'
               with:
                   # Bust the cache at least once a month - output format: YYYY-MM.
                   custom-cache-suffix: $(date -u "+%Y-%m")

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,14 +1,14 @@
 name: PHPUnit Tests
 
 on:
-  pull_request:
-  # Allow manually triggering the workflow.
-  workflow_dispatch:
+    pull_request:
+    # Allow manually triggering the workflow.
+    workflow_dispatch:
 
 # Cancel all previous workflow runs for the same branch that have not yet completed.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
     setup:
@@ -22,8 +22,8 @@ jobs:
         name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }}
 
         env:
-            WP_TESTS_DIR: "/tmp/tests/phpunit"
-            WP_CORE_DIR: "/tmp/wordpress-develop"
+            WP_TESTS_DIR: '/tmp/tests/phpunit'
+            WP_CORE_DIR: '/tmp/wordpress-develop'
 
         steps:
             - name: Checkout
@@ -33,7 +33,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-versions }}
-                  coverage: none  # XDebug can be enabled here 'coverage: xdebug'
+                  coverage: none # XDebug can be enabled here 'coverage: xdebug'
                   tools: composer:v2, phpunit
 
             - name: Install SVN
@@ -49,7 +49,7 @@ jobs:
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             - name: Install Composer dependencies
-              uses: "ramsey/composer-install@v3"
+              uses: 'ramsey/composer-install@v3'
               with:
                   # Bust the cache at least once a month - output format: YYYY-MM.
                   custom-cache-suffix: $(date -u "+%Y-%m")

--- a/.github/workflows/readme-assets-update.yml
+++ b/.github/workflows/readme-assets-update.yml
@@ -8,7 +8,7 @@ jobs:
         name: Push to trunk
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
+            - uses: actions/checkout@v4
             - name: WordPress.org plugin asset/readme update
               uses: 10up/action-wordpress-plugin-asset-update@stable
               env:

--- a/.github/workflows/readme-assets-update.yml
+++ b/.github/workflows/readme-assets-update.yml
@@ -1,17 +1,17 @@
 name: Plugin assets/readme update
 on:
-  push:
-    branches:
-    - trunk
+    push:
+        branches:
+            - trunk
 jobs:
-  trunk:
-    name: Push to trunk
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@stable
-      env:
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        IGNORE_OTHER_FILES: true
+    trunk:
+        name: Push to trunk
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: WordPress.org plugin asset/readme update
+              uses: 10up/action-wordpress-plugin-asset-update@stable
+              env:
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  IGNORE_OTHER_FILES: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/vendor/
+node_modules
+vendor
 package-lock.json
 .phpunit.result.cache
 composer.lock

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
-# Security Policy  
+# Security Policy
 
-## Reporting Security Bugs  
+## Reporting Security Bugs
 
-Please report security bugs found in the site-reviews plugin's source code through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/rocket-lazy-load). The Patchstack team will assist you with verification, CVE assignment and take care of notifying the developers of this plugin.
+Please report security bugs found in the rocket-lazy-load plugin's source code through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/rocket-lazy-load). The Patchstack team will assist you with verification, CVE assignment and take care of notifying the developers of this plugin.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,5 @@
 # Security Policy  
-  
+
 ## Reporting Security Bugs  
-  
+
 Please report security bugs found in the site-reviews plugin's source code through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/rocket-lazy-load). The Patchstack team will assist you with verification, CVE assignment and take care of notifying the developers of this plugin.
----

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -12,16 +12,24 @@
 
 .rocket-lazyload-settings a,
 .rocket-lazyload-settings button {
-	transition: all .275s;
+	transition: all 0.275s;
 }
 
 .rocket-lazyload-settings a {
-	color: #F56640;
+	color: #f56640;
+}
+
+.rocket-lazyload-header a {
+	color: #fff;
+}
+
+.rocket-lazyload-rate-us a {
+	font-weight: 700;
 }
 
 .rocket-lazyload-settings a:hover,
 .rocket-lazyload-settings a:focus {
-	color: #FC8665;
+	color: #fc8665;
 }
 
 .rocket-lazyload-header.rocket-lazyload-header {
@@ -29,21 +37,17 @@
 	display: -ms-flexbox;
 	display: flex;
 	-ms-flex-wrap: wrap;
-		flex-wrap: wrap;
+	flex-wrap: wrap;
 	-webkit-box-align: center;
-	   -ms-flex-align: center;
-		  align-items: center;
+	-ms-flex-align: center;
+	align-items: center;
 	-webkit-box-pack: justify;
-	   -ms-flex-pack: justify;
+	-ms-flex-pack: justify;
 	justify-content: space-between;
 	padding: 28px 38px;
 	font-size: 23px;
-	background: #F56640;
-	color: #FFF;
-}
-
-.rocket-lazyload-header a {
-	color: #FFF;
+	background: #f56640;
+	color: #fff;
 }
 
 .rocket-lazyload-header p {
@@ -51,11 +55,12 @@
 }
 
 .rocket-lazyload-title {
-	color: #EAEAEA;
+	color: #eaeaea;
 	font-size: 23px;
-	font-weight: bold;
+	font-weight: 700;
 	text-transform: uppercase;
 }
+
 .rocket-lazyload-title img {
 	margin-left: -7px;
 	margin-bottom: -5px;
@@ -74,15 +79,12 @@
 	line-height: 1.7;
 }
 
-.rocket-lazyload-rate-us a {
-	font-weight: bold;
-}
-
 .rocket-lazyload-rate-us .stars {
 	display: inline-block;
 	margin-top: 7px;
 	text-decoration: none;
 }
+
 .rocket-lazyload-rate-us .stars span {
 	font-size: 17px;
 	margin: 0 3px;
@@ -90,8 +92,8 @@
 
 .rocket-lazyload-body {
 	padding-top: 25px;
-	background-color: #FFFFFF;
-	border: 1px solid #D9D9D9;
+	background-color: #fff;
+	border: 1px solid #d9d9d9;
 }
 
 .rocket-lazyload-form fieldset {
@@ -101,9 +103,9 @@
 .rocket-lazyload-form legend {
 	display: block;
 	padding: 19px 0 14px;
-	border-bottom: 1px solid #EEEEEE;
+	border-bottom: 1px solid #eee;
 	font-weight: 600;
-	color: #23282D;
+	color: #23282d;
 }
 
 .rocket-lazyload-options {
@@ -124,11 +126,12 @@
 	left: 0;
 	top: 0;
 }
+
 .rocket-lazyload-form [type="checkbox"]:not(:checked):focus,
 .rocket-lazyload-form [type="checkbox"]:checked:focus {
-	box-shadow: none!important; /* system value to override */
-	outline: none!important;
-	border: 0 none!important;
+	box-shadow: none !important; /* system value to override */
+	outline: none !important;
+	border: 0 none !important;
 }
 
 .rocket-lazyload-form [type="checkbox"]:not(:checked) + label,
@@ -140,48 +143,55 @@
 }
 
 /* checkbox aspect */
-.rocket-lazyload-form [type="checkbox"]:not(:checked) + label:before,
-.rocket-lazyload-form [type="checkbox"]:checked + label:before {
-	content: '';
+.rocket-lazyload-form [type="checkbox"]:not(:checked) + label::before,
+.rocket-lazyload-form [type="checkbox"]:checked + label::before {
+	content: "";
 	position: absolute;
-	left: 0; top: 0;
-	width: 28px; height: 28px;
+	left: 0;
+	top: 0;
+	width: 28px;
+	height: 28px;
 	margin: 0 0 0 -24px;
-	border: 2px solid #8BA6B4;
-	background: #FFFFFF;
+	border: 2px solid #8ba6b4;
+	background: #fff;
 	border-radius: 4px;
 }
+
 /* checked mark aspect */
-.rocket-lazyload-form [type="checkbox"]:not(:checked) + label:after,
-.rocket-lazyload-form [type="checkbox"]:checked + label:after {
+.rocket-lazyload-form [type="checkbox"]:not(:checked) + label::after,
+.rocket-lazyload-form [type="checkbox"]:checked + label::after {
 	content: "✓";
 	position: absolute;
 	font-size: 1.6em;
-	color: #8BA6B4;
-	top: 6px; left: -16px;
-	-webkit-transition: all .2s;
-	-moz-transition: all .2s;
-	-ms-transition: all .2s;
-	transition: all .2s;
+	color: #8ba6b4;
+	top: 6px;
+	left: -16px;
+	-webkit-transition: all 0.2s;
+	-moz-transition: all 0.2s;
+	-ms-transition: all 0.2s;
+	transition: all 0.2s;
 }
+
 /* checked mark aspect changes */
-.rocket-lazyload-form [type="checkbox"]:not(:checked) + label:after {
+.rocket-lazyload-form [type="checkbox"]:not(:checked) + label::after {
 	opacity: 0;
 	-webkit-transform: scale(0);
 	-moz-transform: scale(0);
 	-ms-transform: scale(0);
 	transform: scale(0);
 }
-.rocket-lazyload-form [type="checkbox"]:checked + label:after {
+
+.rocket-lazyload-form [type="checkbox"]:checked + label::after {
 	opacity: 1;
 	-webkit-transform: scale(1);
 	-moz-transform: scale(1);
 	-ms-transform: scale(1);
 	transform: scale(1);
 }
+
 /* focus aspect */
-.rocket-lazyload-form [type="checkbox"]:not(:checked):focus + label:before,
-.rocket-lazyload-form [type="checkbox"]:checked:focus + label:before {
+.rocket-lazyload-form [type="checkbox"]:not(:checked):focus + label::before,
+.rocket-lazyload-form [type="checkbox"]:checked:focus + label::before {
 	border-style: dotted;
 	border-color: #40b1d0;
 }
@@ -190,7 +200,7 @@
 	display: inline-block;
 	margin: 0 0 0 20px;
 	vertical-align: -7px;
-	color: #666666;
+	color: #666;
 	font-weight: 600;
 }
 
@@ -200,11 +210,11 @@
 	display: -ms-flexbox;
 	display: flex;
 	-webkit-box-align: center;
-	   -ms-flex-align: center;
-		  align-items: center;
+	-ms-flex-align: center;
+	align-items: center;
 	margin: -10px 20px 20px 20px;
 	padding: 26px;
-	background: #F6F6F6;
+	background: #f6f6f6;
 	border-radius: 4px;
 }
 
@@ -221,16 +231,30 @@
 .rocket-lazyload-cta-promo {
 	display: block;
 	padding: 15px;
-	border: 2px dashed #F56640;
+	border: 2px dashed #f56640;
 	border-bottom: 0;
 	border-radius: 3px 3px 0 0;
 	font-size: 26px;
-	font-weight: bold;
-	color: #F56640;
+	font-weight: 700;
+	color: #f56640;
 }
 
 .rocket-lazyload-cta-promo strong {
-	color: #0E1B23;
+	color: #0e1b23;
+}
+
+.rocket-lazyload-form .button-primary {
+	padding: 11px 20px;
+	height: auto;
+	background-color: #f56640;
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+	border: none;
+	font-size: 15px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	border-radius: 3px;
+	font-weight: 700;
+	text-shadow: none;
 }
 
 .rocket-lazyload-cta-block.rocket-lazyload-cta-block .button-primary {
@@ -244,22 +268,22 @@
 	margin: 1.5em auto;
 	padding-left: 35px;
 	font-size: 13px;
-	color: #71787D;
+	color: #71787d;
 }
 
-.rll-upgrade-item:before {
+.rll-upgrade-item::before {
 	content: "✓";
 	position: absolute;
 	top: 0;
 	left: 0;
 	font-size: 1.7em;
-	color: #39CE9A;
-	font-weight: normal;
+	color: #39ce9a;
+	font-weight: 400;
 }
 
 .rll-upgrade-item strong {
-	color: #39CE9A;
-	font-weight: bold;
+	color: #39ce9a;
+	font-weight: 700;
 }
 
 .rocket-lazyload-upgrade p {
@@ -270,13 +294,13 @@
 	margin-bottom: 8px;
 	font-size: 14px;
 	letter-spacing: 1px;
-	color: #F56640;
+	color: #f56640;
 }
 
 .rocket-lazyload-bigtext {
 	font-size: 28px;
-	font-weight: bold;
-	color: #0E1B23;
+	font-weight: 700;
+	color: #0e1b23;
 }
 
 .rocket-lazyload-rocket-logo {
@@ -285,33 +309,15 @@
 }
 
 .rocket-lazyload-form .submit {
-	padding: 28px 0 32px 24px;
-}
-
-.rocket-lazyload-form .submit {
 	margin: 0;
 	padding: 34px 45px;
-	background: #F6F6F6;
-}
-
-.rocket-lazyload-form .button-primary {
-	padding: 11px 20px;
-	height: auto;
-	background-color: #F56640;
-	box-shadow: 0 4px 8px rgba(0, 0, 0, .1);
-	border: none;
-	font-size: 15px;
-	text-transform: uppercase;
-	letter-spacing: .04em;
-	border-radius: 3px;
-	font-weight: bold;
-	text-shadow: none;
+	background: #f6f6f6;
 }
 
 .rocket-lazyload-form .button-primary:hover,
 .rocket-lazyload-form .button-primary:focus {
 	text-shadow: none;
-	background: #FC8665;
+	background: #fc8665;
 	transform: translateY(-3px);
 }
 
@@ -325,17 +331,17 @@
 	display: -webkit-flex;
 	display: -ms-flexbox;
 	display: flex;
-	  -webkit-box-align: center;
+	-webkit-box-align: center;
 	-webkit-align-items: center;
-		 -ms-flex-align: center;
-	 -ms-grid-row-align: center;
-			align-items: center;
+	-ms-flex-align: center;
+	-ms-grid-row-align: center;
+	align-items: center;
 	float: none;
 	width: auto;
 	padding: 5px 45px 5px 0;
 	border: 0 none;
 	box-shadow: none;
-	color: #FFF;
+	color: #fff;
 	background: #2e3243;
 }
 
@@ -347,14 +353,15 @@
 	height: 22px;
 	padding: 0;
 	margin-top: -11px;
-	background: #FFF;
+	background: #fff;
 	color: #2e3243;
 	border-radius: 50%;
-	transition: all .275s;
+	transition: all 0.275s;
 }
+
 .rktll-imagify-notice .rktll-cross:hover,
 .rktll-imagify-notice .rktll-cross:focus {
-	opacity: .5;
+	opacity: 0.5;
 	color: #2e3243;
 	text-decoration: none;
 	border-bottom: 0 none;
@@ -371,7 +378,7 @@
 	position: relative;
 	top: 2px;
 	left: 1px;
-	transition: all .275s;
+	transition: all 0.275s;
 }
 
 .rktll-imagify-notice .rktll-imagify-logo,
@@ -408,14 +415,15 @@
 	height: auto;
 	font-weight: 600;
 	font-size: 14px;
-	box-shadow: 0 3px 0 rgba(0,0,0,.15);
+	box-shadow: 0 3px 0 rgba(0, 0, 0, 0.15);
 	border: 0 none;
 	padding: 4px 18px;
-	background: #40B1D0;
-	text-shadow: 1px 1px 1px rgba(0,0,0,.2);
+	background: #40b1d0;
+	text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
 }
 
 @media (max-width: 820px) {
+
 	.rocket-lazyload-header .rocket-lazyload-rate-us {
 		margin: 1.5em 0 0;
 		text-align: left;
@@ -423,13 +431,16 @@
 }
 
 @media (max-width: 650px) {
+
 	.rocket-lazyload-upgrade {
 		-ms-flex-wrap: wrap;
 		flex-wrap: wrap;
 	}
+
 	.rocket-lazyload-option {
 		margin-left: 25px;
 	}
+
 	.rocket-lazyload-form [type="checkbox"]:not(:checked) + label,
 	.rocket-lazyload-form [type="checkbox"]:checked + label {
 		padding-left: 0;

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
 		}
 	},
 	"autoload-dev": {
-        "psr-4": {
-            "RocketLazyLoadPlugin\\Tests\\Unit\\": "tests/Unit",
-            "RocketLazyLoadPlugin\\Tests\\Integration\\": "tests/Integration"
-        }
-    },
+		"psr-4": {
+			"RocketLazyLoadPlugin\\Tests\\Unit\\": "tests/Unit",
+			"RocketLazyLoadPlugin\\Tests\\Integration\\": "tests/Integration"
+		}
+	},
 	"require": {
 		"php": ">=7.4",
 		"composer/installers": "^2.0",
@@ -75,7 +75,7 @@
 		"phpcs": "vendor/bin/phpcs",
 		"phpcbf": "vendor/bin/phpcbf",
 		"phpstan": "vendor/bin/phpstan analyze --memory-limit=2G",
-        "test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
+		"test-unit": "\"vendor/bin/phpunit\" --testsuite unit --colors=always --configuration tests/Unit/phpunit.xml.dist",
 		"test-integration": "\"vendor/bin/phpunit\" --testsuite integration --colors=always --configuration tests/Integration/phpunit.xml.dist",
 		"post-install-cmd": [
 			"\"vendor/bin/mozart\" compose",

--- a/package.json
+++ b/package.json
@@ -1,25 +1,29 @@
 {
-  "name": "rocket-lazy-load",
-  "version": "2.4.0",
-  "description": "Standalone LazyLoad plugin for WordPress (based on WP Rocket) ",
-  "author": "WP Media",
-  "license": "GPL-2.0-or-later",
-  "keywords": ["lazyload", "wordpress", "plugin"],
-  "homepage": "https://github.com/wp-media/rocket-lazy-load",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/wp-media/rocket-lazy-load.git"
-  },
-  "bugs": {
-    "url": "https://github.com/wp-media/rocket-lazy-load/issues"
-  },
+	"name": "rocket-lazy-load",
+	"version": "2.4.0",
+	"description": "Standalone LazyLoad plugin for WordPress (based on WP Rocket) ",
+	"author": "WP Media",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"lazyload",
+		"wordpress",
+		"plugin"
+	],
+	"homepage": "https://github.com/wp-media/rocket-lazy-load",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/wp-media/rocket-lazy-load.git"
+	},
+	"bugs": {
+		"url": "https://github.com/wp-media/rocket-lazy-load/issues"
+	},
 	"devDependencies": {
 		"@wordpress/scripts": "^32.0.0"
 	},
 	"scripts": {
 		"format": "wp-scripts format",
 		"lint:css": "wp-scripts lint-style",
-    "lint:md:docs": "wp-scripts lint-md-docs",
-    "lint:pkg-json": "wp-scripts lint-pkg-json"
+		"lint:md:docs": "wp-scripts lint-md-docs",
+		"lint:pkg-json": "wp-scripts lint-pkg-json"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rocket-lazy-load",
   "version": "2.4.0",
-  "description": "Standalone LazyLoad plugin for WordPress (based on WP Rocket) ",
+  "description": "Standalone LazyLoad plugin for WordPress (based on WP Rocket)",
   "author": "WP Media",
   "license": "GPL-2.0-or-later",
   "keywords": ["lazyload", "wordpress", "plugin"],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "rocket-lazy-load",
+  "version": "2.4.0",
+  "description": "Standalone LazyLoad plugin for WordPress (based on WP Rocket) ",
+  "author": "WP Media",
+  "license": "GPL-2.0-or-later",
+  "keywords": ["lazyload", "wordpress", "plugin"],
+  "homepage": "https://github.com/wp-media/rocket-lazy-load",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wp-media/rocket-lazy-load.git"
+  },
+  "bugs": {
+    "url": "https://github.com/wp-media/rocket-lazy-load/issues"
+  },
+	"devDependencies": {
+		"@wordpress/scripts": "^32.0.0"
+	},
+	"scripts": {
+		"format": "wp-scripts format",
+		"lint:css": "wp-scripts lint-style",
+    "lint:md:docs": "wp-scripts lint-md-docs",
+    "lint:pkg-json": "wp-scripts lint-pkg-json"
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Lazy loading is a key performance technique to make your site faster. You’ll r
 
 [Lazy loading your images on WordPress](https://wp-rocket.me/blog/lazy-loading-wordpress-5-5/) will help you achieve a better PageSpeed Insights score for three main reasons:
 
-* You’ll address a specific PageSpeed Insights recommendation: [Defer offscreen images](https://wp-rocket.me/google-core-web-vitals-wordpress/defer-offscreen-images/, which means image lazy loading.
+* You’ll address a specific PageSpeed Insights recommendation: [Defer offscreen images](https://wp-rocket.me/google-core-web-vitals-wordpress/defer-offscreen-images/), which means image lazy loading.
 * You’ll improve the performance of two key metrics: [First Input Delay](https://wp-rocket.me/google-core-web-vitals-wordpress/improve-first-input-delay/) (Core Web Vital) and [Total Blocking Time](https://wp-rocket.me/lighthouse-performance-score-wordpress/reduce-total-blocking-time/) (Lighthouse metric).
 * You’ll [make fewer HTTP requests](https://wp-rocket.me/blog/reduce-http-requests-speed-wordpress-site/) – that is another way to boost your site speed and [improve the Largest Contentful Paint score](https://wp-rocket.me/google-core-web-vitals-wordpress/improve-largest-contentful-paint/) (another Core Web Vital).
 
@@ -29,10 +29,11 @@ Take a look at our complete list of reasons [why you should use lazy loading](ht
 In order to build the plugin you need have composer installed.
 
 Once it is the case you can follow these steps:
-- Download the zip from the plugin and unzip in a folder.
-- Move inside that folder and run the command `composer i` to install the full plugin and let the script installing protected dependencies run.
-- Run the command `composer i --no-dev --no-scripts -o` to install a production version from dependencies.
-- Zip back the folder and you have a working version from the plugin.
+
+* Download the zip from the plugin and unzip in a folder.
+* Move inside that folder and run the command `composer i` to install the full plugin and let the script installing protected dependencies run.
+* Run the command `composer i --no-dev --no-scripts -o` to install a production version from dependencies.
+* Zip back the folder and you have a working version from the plugin.
 
 ## Dependencies
 
@@ -46,6 +47,7 @@ LazyLoad script: [https://github.com/verlok/lazyload](https://github.com/verlok/
 ## Frequently Asked Questions
 
 ### How can I use native lazyload?
+
 To use native lazyload on browsers supporting this feature, you need to use the following line:
 
 `add_filter( 'rocket_use_native_lazyload', '__return_true' );`
@@ -67,7 +69,7 @@ add_filter( 'do_rocket_lazyload', '__return_false' );
 }
 `
 
-###  How can I deactivate Lazy Load on some images?
+### How can I deactivate Lazy Load on some images?
 
 Simply add a `data-no-lazy="1"` property in you `img` or `iframe` tag.
 
@@ -117,6 +119,7 @@ You can report any security bugs found in the source code of the site-reviews pl
 * [Increase Max upload file size](https://wordpress.org/plugins/upload-max-file-size/) is the best plugin to increase the upload file size limit to any value with one click.
 
 ## Changelog
+
 = 2.4.0 =
 Security: Fix an authenticated Stored Cross-Site Scripting (XSS) vulnerability reported by Pathstack.
 
@@ -124,7 +127,7 @@ Security: Fix an authenticated Stored Cross-Site Scripting (XSS) vulnerability r
 Updated version to fix a mismatch between the tag of the release on Github and the release version which leads to a deployment issue that.
 
 = 2.3.8 =
-Enhancement: Launchpad compatibility (see https://github.com/wp-launchpad)
+Enhancement: Launchpad compatibility (see [https://github.com/wp-launchpad])
 Enhancement: Raised compatibility with PHP > 7.3
 Bug: Removed `wp-media/rocket-lazyload-common` from vendors
 Enhancement: Raised `wp-media/rocket-lazyload-common` to 3.0
@@ -138,13 +141,13 @@ Enhancement: Change WP readme content.
 
 = 2.3.4 =
 Enhancement: Allow `<a>` tags to lazyload background images
-Enhancement: Add <noscript> tag to lazyloaded picture elements
+Enhancement: Add `<noscript>` tag to lazyloaded picture elements
 Bugfix: Prevent a Fatal error related to the League Container package conflict with WooCommerce 4.4
 Bugfix: Update lazyload for background images support for new version of lazyload script
 Bugfix: Correctly apply the rocket-lazyload class on elements with a background-image and an empty class value
 Bugfix: Correctly apply the rocket-lazyloadclass on elements with malformed HTML
 Bugfix: Prevent a display issue with background-images when using different types of quotes around the URL
-Bugfix: Prevent Layout from breaking when <img> alt attribute has any html encoded characters
+Bugfix: Prevent Layout from breaking when `<img>` alt attribute has any html encoded characters
 
 = 2.3.3 =
 Enhancement: Add data-skip-lazy and skip-lazy class to exclusions list as part of the interoperability initiative between lazyload plugins
@@ -168,6 +171,7 @@ Bugfix: Prevent broken image in some cases for picture element
 Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a picture element
 
 = 2.2.3 =
+
 * Enhancement: Improve compatibility for the picture element
 * Enhancement: Apply lazyload on background images set on section, span and li elements
 * Enhancement: also pass $width and $height values to the rocket_lazyload_placeholder filter
@@ -176,10 +180,12 @@ Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a 
 * Bugfix: Exclude Enfold avia-background-fixed background images and data-large_image from lazyload
 
 = 2.2.2 =
+
 * Bugfix: Auto-exclude data-height-percentage attribute to prevent display issues
 * Bugfix: Correctly handle responsive videos using fitVids again
 
 = 2.2.1 =
+
 * Enhancement: add a way to customize the lazyload script options
 * Bugfix: Prevent error on Internet Explorer 11
 * Bugfix: Prevent conflict with WooCommerce variation swatches
@@ -187,11 +193,13 @@ Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a 
 * Bugfix: Prevent issue when the original `src` attribute uses single quotes
 
 = 2.2 =
+
 * Enhancement: Update lazyload script to the latest version
 * Enhancement: Use the dimensions of the original image for the placeholder size when possible, to reduce content reflow
 * Enhancement: Ignore images using the new loading attribute introduce by Chrome for browser-native lazyload
 
 = 2.1.5 =
+
 * Bugfix: Prevent matching with the wrong data when a data-style attribute is on a div for background images
 * Remove data-cfasync="false" by default
 * Enhancement: Add filter rocket_lazyload_script_tag to modify the lazyload script HTML if needed
@@ -199,12 +207,15 @@ Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a 
 * Enhancement: Improve MutationObserver code to only call the lazyload update method if an image/iframe or element with .rocket-lazyload is contained in the new node(s) added to the DOM
 
 = 2.1.4 =
+
 * Regression fix: Correctly exclude scripts from lazyload again
 
 = 2.1.3 =
+
 * Bugfix: Ignore content inside noscript tags to prevent modifying them and causing some display issues
 
 = 2.1.2 =
+
 * Enhancement: Update lazyload script to the latest version
 * Enhancement: Add a way to lazyload the Youtube thumbnail image
 * Enhancement: Add width and height attributes to the Youtube thumbnail image depending on the resolution
@@ -215,39 +226,48 @@ Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a 
 
 
 = 2.1.1 =
+
 * Bugfix: Correctly apply lazyload on `picture` elements
 * Bugfix: Prevent double loading of an image when an `img` element inside a `picture` element only has a `srcset` attribute and no `src` attribute
 
 = 2.1 =
+
 * Enhancement: Update lazyload script to the latest version
 * Enhancement: Apply lazyload on picture elements found on the page
 * Enhancement: Apply lazyload on div elements with a background image found on the page. See FAQ for more info.
 
 = 2.0.4 =
+
 * Enhancement: Add filter for iframe lazyload pattern exclusion
 * Enhancement: Auto-exclude soliloquy-image pattern from lazyload
 * Bugfix: Prevent issue when an image/iframe is duplicated on the same page
 * Bugfix: Prevent W3C validation error for the SVG placeholder
 
 = 2.0.3.2 =
+
 * Bugfix: Correctly ignore inline scripts with line breaks inside
 
 = 2.0.3.1 =
+
 * Bugfix: Correct an issue preventing lazyload from working
 
 = 2.0.3 =
+
 * Bugfix: Prevent incorrect display if JavaScript is disabled
 * Bugfix: Don't apply lazyload on Divi/Extra/Beaver Builder Editor pages
 * Bugfix: Use the correct URL for each iframe when multiple iframes are on the same page
 * Bugfix: Ignore content inside inline script tags to prevent applying lazyload in it
 
 = 2.0.2 =
+
 * Bugfix: Fix an error in the compatibility for the AMP plugin
 
 = 2.0.1 =
+
 * Bugfix: Prevent a fatal error on case sensitive operating systems
 
 = 2.0 =
+
 * Enhancement: Lazyload is now applied on the template_redirect hook, which should allow the plugin to apply the optimization on more images and encountering less conflicts at the same time
 * Enhancement: Specifically target with the lazyload script images/iframes elements with a data-lazy-src attribute
 * Enhancement: Update lazyload script to the latest version
@@ -259,6 +279,7 @@ Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a 
 * Bugfix: Update CSS for the Youtube thumbnail option to prevent issue with the Gutenberg embeds block
 
 = 1.4.9 =
+
 * Enhancement: Update lazyload script to the latest available version
 * Enhancement: Use lazy-sizes to prevent W3C validation error when sizes is defined but srcset is not
 * Enhancement: Parse images or iframes only if the element is selected to be lazyloaded in the options
@@ -266,6 +287,7 @@ Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a 
 * Fix: Prevent PHP Notice with WooCommerce for product images
 
 = 1.4.8 =
+
 * Notice: Minimum WordPress version required is now 4.7
 * Enhancement: Update lazyload script version
 * Enhancement: Remove placeholder image to improve perceived loading time
@@ -279,47 +301,59 @@ Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a 
 * Fix: Correct text domain for translations (thanks @ Chantal Coolsma)
 
 = 1.4.7 =
+
 * Fix compatibility with infinite scroll
 * Prevent lazyload on masterSlider images
 
 = 1.4.6 =
+
 * Correctly include version 8.5.2 of lazyload script
 * Prevent 404 error on lazyload script if URL contains "-v"
 
 = 1.4.5 =
+
 * Rename Setting Page Name in WP Menu
 * New Product Banner in Settings Page
 * Conditionally load a different version of the script depending on browser support of IntersectionObserver
 * Fix a bug where images initially hidden are not correctly displayed when coming into view (slider, tabs, accordion)
 
 = 1.4.4 =
+
 * Admin Redesign
 
 = 1.4.3 =
+
 * Plugin is compatible again with PHP < 5.4
 
 = 1.4.2 =
+
 * Update lazyload script to bring back compatibility with IE9/10
 
 = 1.4.1 =
+
 * Fix bug caused by a too aggressive cleanup
 
 = 1.4 =
+
 * New option: replace Youtube videos by thumbnail. This option can improve your loading time a lot, especially if you have multiple videos on the same page
 
 = 1.3.3 =
+
 * 2017-09-16
 * Prevent scripts and styles being removed during html parsing
 
 = 1.3.2 =
+
 * 2017-09-12
 * Fix images not displaying in certain conditions because image attributes exclusion was not working correctly
 
 = 1.3.1 =
+
 * 2017-09-07
 * Don't apply lazyload on Divi slider
 
 = 1.3 =
+
 * 2017-09-01
 * Improve HTML parsing of images and iframes to be faster and more efficient
 * Make the lazyload compatible with fitVids for iframes
@@ -328,20 +362,24 @@ Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a 
 * Don't apply lazyload on upPrev thumbnail
 
 = 1.2.1 =
+
 * 2017-08-22
 * Fix missing lazyload script
 * Don't lazyload for images in REST API requests
 
 = 1.2 =
+
 * 2017-08-22
 * Update lazyload script to latest version
 * Change the way the script is loaded
 
 = 1.1.1 =
+
 * 2017-02-13
 * Bug fix: Remove use of short tag to prevent 500 error on some installations
 
 = 1.1 =
+
 * 2017-02-12
 * *New*
 * JS library updated
@@ -350,27 +388,33 @@ Bugfix: Prevent wrong lazy attributes for srcset and sizes on an image inside a 
 * New options page
 
 = 1.0.4 =
+
 * 2015-04-28
 * Bug Fix: Resolved a conflict between LazyLoad & Emoji since WordPress 4.2
 
 = 1.0.3 =
+
 * 2015-01-08
 * Bug Fix: Don't apply LazyLoad on captcha from Really Simple CAPTCHA to prevent conflicts.
 
 = 1.0.2 =
+
 * 2014-12-28
 * Improvement: Add « rocket_lazyload_html » filter to manage the output that will be printed.
 
 = 1.0.1.1 =
+
 * 2014-07-25
 * Fix stupid error with new regex in 1.0.1
 
 = 1.0.1 =
+
 * 2014-07-16
 * Bug Fix: when a IMG tag or content (widget or post) contains the string "data-no-lazy", all IMG tags were ignored instead of one.
 * Security fix: The preg_replace() could lead to a XSS vuln, thanks to Alexander Concha
 * Code compliance
 
 = 1.0 =
+
 * 2014-01-01
 * Initial release.

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Take a look at our complete list of reasons [why you should use lazy loading](ht
 
 ## How to build the plugin
 
-In order to build the plugin you need have composer installed.
+In order to build the plugin you need to have Composer installed.
 
 Once it is the case you can follow these steps:
 
@@ -124,10 +124,10 @@ You can report any security bugs found in the source code of the site-reviews pl
 Security: Fix an authenticated Stored Cross-Site Scripting (XSS) vulnerability reported by Pathstack.
 
 = 2.3.9 =
-Updated version to fix a mismatch between the tag of the release on Github and the release version which leads to a deployment issue that.
+Updated version to fix a mismatch between the tag of the release on GitHub and the release version which leads to a deployment issue that.
 
 = 2.3.8 =
-Enhancement: Launchpad compatibility (see [https://github.com/wp-launchpad])
+Enhancement: Launchpad compatibility (see [wp-launchpad](https://github.com/wp-launchpad))
 Enhancement: Raised compatibility with PHP > 7.3
 Bug: Removed `wp-media/rocket-lazyload-common` from vendors
 Enhancement: Raised `wp-media/rocket-lazyload-common` to 3.0


### PR DESCRIPTION
# Description

Add `@wordpress/scripts` package for formatting and linting

## Type of change

- [x] Chore

## Technical description

### Documentation

Adds a Node-based developer toolchain (`@wordpress/scripts`) to support formatting and linting, alongside a broad set of whitespace/formatting updates across docs, CSS, Composer config, and GitHub workflows.

**Changes:**
- Add `package.json` with `@wordpress/scripts` and npm scripts for formatting/linting.
- Reformat documentation/CSS and normalize various config files.
- Re-indent GitHub workflow YAML files.
