### PR TITLE
Add Render class

### DIFF
--- a/configs/providers.php
+++ b/configs/providers.php
@@ -3,6 +3,7 @@
 defined( 'ABSPATH' ) || exit;
 
 return [
+	\RocketLazyLoadPlugin\Render\ServiceProvider::class,
 	\RocketLazyLoadPlugin\ServiceProvider\AdminServiceProvider::class,
 	\RocketLazyLoadPlugin\ServiceProvider\ImagifyNoticeServiceProvider::class,
 	\RocketLazyLoadPlugin\ServiceProvider\LazyloadServiceProvider::class,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,6 +12,7 @@
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
 	<exclude-pattern>/src/Dependencies/*</exclude-pattern>
+	<eclude-pattern>/node_modules/*</exclude-pattern>
 
 	<!-- ** HOW TO SCAN ** -->
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,7 +12,7 @@
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
 	<exclude-pattern>/src/Dependencies/*</exclude-pattern>
-	<eclude-pattern>/node_modules/*</exclude-pattern>
+	<exclude-pattern>/node_modules/*</exclude-pattern>
 
 	<!-- ** HOW TO SCAN ** -->
 

--- a/src/Admin/AdminPage.php
+++ b/src/Admin/AdminPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace RocketLazyLoadPlugin\Admin;
 
 use WPMedia\Options\OptionArray;
+use RocketLazyLoadPlugin\Render\Render;
 
 class AdminPage {
 	/**
@@ -21,21 +22,21 @@ class AdminPage {
 	private $options;
 
 	/**
-	 * Template path
+	 * Render instance
 	 *
-	 * @var string
+	 * @var Render
 	 */
-	private $template_path;
+	private $render;
 
 	/**
 	 * Constructor
 	 *
 	 * @param OptionArray $options Option array instance.
-	 * @param string      $template_path Template path.
+	 * @param Render      $render  Render instance.
 	 */
-	public function __construct( OptionArray $options, string $template_path ) {
+	public function __construct( OptionArray $options, Render $render ) {
 		$this->options       = $options;
-		$this->template_path = $template_path;
+		$this->render        = $render;
 	}
 
 	/**
@@ -116,26 +117,6 @@ class AdminPage {
 			],
 		];
 
-		$this->render_template( 'admin-page', $data );
-	}
-
-	/**
-	 * Renders the given template if it's readable.
-	 *
-	 * @since 2.0
-	 *
-	 * @param string $template Template name.
-	 * @param array  $data     Data to pass to the template.
-	 *
-	 * @return void
-	 */
-	protected function render_template( $template, array $data = [] ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$template_path = $this->template_path . $template . '.php';
-
-		if ( ! is_readable( $template_path ) ) {
-			return;
-		}
-
-		include $template_path;
+		$this->render->render_template( 'admin-page', $data );
 	}
 }

--- a/src/Admin/AdminPage.php
+++ b/src/Admin/AdminPage.php
@@ -35,8 +35,8 @@ class AdminPage {
 	 * @param Render      $render  Render instance.
 	 */
 	public function __construct( OptionArray $options, Render $render ) {
-		$this->options       = $options;
-		$this->render        = $render;
+		$this->options = $options;
+		$this->render  = $render;
 	}
 
 	/**

--- a/src/Admin/ImagifyNotice.php
+++ b/src/Admin/ImagifyNotice.php
@@ -3,21 +3,23 @@ declare(strict_types=1);
 
 namespace RocketLazyLoadPlugin\Admin;
 
+use RocketLazyLoadPlugin\Render\Render;
+
 class ImagifyNotice {
 	/**
-	 * Template path
+	 * Render instance
 	 *
-	 * @var string
+	 * @var Render
 	 */
-	private $template_path;
+	private $render;
 
 	/**
 	 * Constructor
 	 *
-	 * @param string $template_path Template path.
+	 * @param Render $render Render instance.
 	 */
-	public function __construct( $template_path ) {
-		$this->template_path = $template_path;
+	public function __construct( Render $render ) {
+		$this->render = $render;
 	}
 
 	/**
@@ -28,25 +30,6 @@ class ImagifyNotice {
 	 * @return void
 	 */
 	public function display_notice() {
-		$this->render_template( 'imagify-notice' );
-	}
-
-	/**
-	 * Renders the given template if it's readable.
-	 *
-	 * @since 2.0
-	 *
-	 * @param string $template Template name.
-	 *
-	 * @return void
-	 */
-	protected function render_template( $template ): void {
-		$template_path = $this->template_path . $template . '.php';
-
-		if ( ! is_readable( $template_path ) ) {
-			return;
-		}
-
-		include $template_path;
+		$this->render->render_template( 'imagify-notice' );
 	}
 }

--- a/src/Render/Render.php
+++ b/src/Render/Render.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace RocketLazyLoadPlugin\Render;
+
+class Render {
+    /**
+     * Template path
+     *
+     * @var string
+     */
+    private $template_path;
+
+    /**
+     * Constructor
+     *
+     * @param string $template_path Template path.
+     */
+    public function __construct(string $template_path) {
+        $this->template_path = $template_path;
+    }
+
+    /**
+	 * Renders the given template if it's readable.
+	 *
+	 * @since 2.0
+	 *
+	 * @param string $template Template name.
+	 * @param array  $data     Data to pass to the template.
+	 *
+	 * @return void
+	 */
+	public function render_template( $template, array $data = [] ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		$template_path = $this->template_path . $template . '.php';
+
+		if ( ! is_readable( $template_path ) ) {
+			return;
+		}
+
+		include $template_path;
+	}
+}

--- a/src/Render/Render.php
+++ b/src/Render/Render.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 namespace RocketLazyLoadPlugin\Render;
 
 class Render {
-    /**
-     * Template path
-     *
-     * @var string
-     */
-    private $template_path;
+	/**
+	 * Template path
+	 *
+	 * @var string
+	 */
+	private $template_path;
 
-    /**
-     * Constructor
-     *
-     * @param string $template_path Template path.
-     */
-    public function __construct(string $template_path) {
-        $this->template_path = $template_path;
-    }
+	/**
+	 * Constructor
+	 *
+	 * @param string $template_path Template path.
+	 */
+	public function __construct( string $template_path ) {
+		$this->template_path = $template_path;
+	}
 
-    /**
+	/**
 	 * Renders the given template if it's readable.
 	 *
 	 * @since 2.0

--- a/src/Render/ServiceProvider.php
+++ b/src/Render/ServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace RocketLazyLoadPlugin\Render;
+
+use RocketLazyLoadPlugin\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+
+class ServiceProvider extends AbstractServiceProvider {
+	/**
+	 * Services provided by this provider
+	 *
+	 * @var array
+	 */
+	protected $provides = [
+		Render::class,
+	];
+
+	/**
+	 * Check if the service provider provides a specific service.
+	 *
+	 * @param string $id The id of the service.
+	 *
+	 * @return bool
+	 */
+	public function provides( string $id ): bool {
+		return in_array( $id, $this->provides, true );
+	}
+
+	/**
+	 * Registers the provided classes
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		$this->getContainer()->add( Render::class )
+			->addArgument( $this->getContainer()->get( 'template_path' ) );
+	}
+}

--- a/src/ServiceProvider/AdminServiceProvider.php
+++ b/src/ServiceProvider/AdminServiceProvider.php
@@ -5,6 +5,7 @@ namespace RocketLazyLoadPlugin\ServiceProvider;
 
 use RocketLazyLoadPlugin\Admin\AdminPage;
 use RocketLazyLoadPlugin\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
+use RocketLazyLoadPlugin\Render\Render;
 use RocketLazyLoadPlugin\Subscriber\AdminPageSubscriber;
 use WPMedia\Options\OptionArray;
 
@@ -51,7 +52,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements ServicePro
 			->addArguments(
 				[
 					OptionArray::class,
-					$this->getContainer()->get( 'template_path' ),
+					Render::class,
 				]
 			);
 

--- a/src/ServiceProvider/ImagifyNoticeServiceProvider.php
+++ b/src/ServiceProvider/ImagifyNoticeServiceProvider.php
@@ -5,6 +5,7 @@ namespace RocketLazyLoadPlugin\ServiceProvider;
 
 use RocketLazyLoadPlugin\Dependencies\League\Container\ServiceProvider\AbstractServiceProvider;
 use RocketLazyLoadPlugin\Admin\ImagifyNotice;
+use RocketLazyLoadPlugin\Render\Render;
 use RocketLazyLoadPlugin\Subscriber\ImagifyNoticeSubscriber;
 
 class ImagifyNoticeServiceProvider extends AbstractServiceProvider implements ServiceProviderSubscribersInterface {
@@ -47,7 +48,7 @@ class ImagifyNoticeServiceProvider extends AbstractServiceProvider implements Se
 	 */
 	public function register(): void {
 		$this->getContainer()->add( ImagifyNotice::class )
-			->addArgument( $this->getContainer()->get( 'template_path' ) );
+			->addArgument( Render::class );
 
 		$this->getContainer()->addShared( ImagifyNoticeSubscriber::class )
 			->addArgument( ImagifyNotice::class );


### PR DESCRIPTION
# Description

Add a `Render` class to manage the display of views as dependency for other classes

## Type of change

- [x] Chore


## Technical description

### Documentation

This PR introduces a centralized `Render` service (and its DI service provider) to handle view/template inclusion, then wires existing admin UI classes to depend on that service instead of a raw template path string.

**Changes:**
- Added `RocketLazyLoadPlugin\Render\Render` plus a dedicated `RocketLazyLoadPlugin\Render\ServiceProvider` to register it in the container.
- Updated `AdminPage` and `ImagifyNotice` to receive a `Render` instance and delegate template rendering to it.
- Registered the new Render service provider and updated existing service providers to inject `Render::class`.
