### PR TITLE
Add missing documentation for filters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,14 +60,14 @@ You can use the `do_rocket_lazyload` filter.
 
 Here is an example to put in functions.php files that disable lazyload on posts:
 
-`
+```
 add_action( 'wp', 'deactivate_rocket_lazyload_on_single' );
-function deactivate_rocket_lazyload_on_single() {
-if ( is_single() ) {
-add_filter( 'do_rocket_lazyload', '__return_false' );
+    function deactivate_rocket_lazyload_on_single() {
+    if ( is_single() ) {
+        add_filter( 'do_rocket_lazyload', '__return_false' );
+    }
 }
-}
-`
+```
 
 ### How can I deactivate Lazy Load on some images?
 
@@ -83,12 +83,46 @@ You can use the `rocket_lazyload_threshold` filter.
 
 Code sample:
 
-`
+```
 function rocket_lazyload_custom_threshold( $threshold ) {
-return 100;
+    return 100;
 }
 add_filter( 'rocket_lazyload_threshold', 'rocket_lazyload_custom_threshold' );
-`
+```
+
+### How to remove the `<noscript>` tag
+
+You can use the `rocket_lazyload_noscript` filter to disable the addition of the `<noscript>` tag used for compatibility when JS is disabled.
+
+`add_filter( 'rocket_lazyload_noscript', '__return_false' );`
+
+### How to change the image placeholder for lazyloaded images
+
+You can use the `rocket_lazyload_placeholder` to change the default placeholder for lazyloaded images.
+
+```
+function rocket_lazyload_custom_placeholder( $placeholder ) {
+    return 'default.jpg';
+}
+add_filter( 'rocket_lazyload_placeholder')
+```
+
+### How to change the HTML output before sending to the browser
+
+You can use the `rocket_lazyload_html` filter to modify the HTML output generated after applying the lazyload and before sending it to the browser.
+
+### How to exclude YouTube videos from lazyload
+
+You can use the `rocket_lazyload_exclude_youtube_thumbnail` filter to exclude patterns matching with the YouTube videos you don't want to lazyload.
+
+```
+function rocket_lazyload_exclude_youtube( $patterns ) {
+    $patterns[] = 'string_to_match';
+
+    return $patterns;
+}
+add_filter( 'rocket_lazyload_exclude_youtube_thumbnail', 'rocket_lazyload_exclude_youtube' );
+```
 
 ### I use plugin X and my images don't show anymore
 

--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ You can use the `rocket_lazyload_placeholder` to change the default placeholder 
 function rocket_lazyload_custom_placeholder( $placeholder ) {
     return 'default.jpg';
 }
-add_filter( 'rocket_lazyload_placeholder')
+add_filter( 'rocket_lazyload_placeholder', 'rocket_lazyload_custom_placeholder' );
 ```
 
 ### How to change the HTML output before sending to the browser

--- a/readme.txt
+++ b/readme.txt
@@ -94,12 +94,12 @@ You can use the `rocket_lazyload_noscript` filter to disable the addition of the
 
 You can use the `rocket_lazyload_placeholder` to change the default placeholder for lazyloaded images.
 
-```
+`
 function rocket_lazyload_custom_placeholder( $placeholder ) {
     return 'default.jpg';
 }
 add_filter( 'rocket_lazyload_placeholder', 'rocket_lazyload_custom_placeholder' );
-```
+`
 
 = How to change the HTML output before sending to the browser =
 

--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,7 @@ You can use the `rocket_lazyload_placeholder` to change the default placeholder 
 function rocket_lazyload_custom_placeholder( $placeholder ) {
     return 'default.jpg';
 }
-add_filter( 'rocket_lazyload_placeholder')
+add_filter( 'rocket_lazyload_placeholder', 'rocket_lazyload_custom_placeholder' );
 ```
 
 = How to change the HTML output before sending to the browser =
@@ -109,14 +109,14 @@ You can use the `rocket_lazyload_html` filter to modify the HTML output generate
 
 You can use the `rocket_lazyload_exclude_youtube_thumbnail` filter to exclude patterns matching with the YouTube videos you don't want to lazyload.
 
-```
+`
 function rocket_lazyload_exclude_youtube( $patterns ) {
     $patterns[] = 'string_to_match';
 
     return $patterns;
 }
 add_filter( 'rocket_lazyload_exclude_youtube_thumbnail', 'rocket_lazyload_exclude_youtube' );
-```
+`
 
 = I use plugin X and my images don't show anymore =
 

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,40 @@ function rocket_lazyload_custom_threshold( $threshold ) {
 add_filter( 'rocket_lazyload_threshold', 'rocket_lazyload_custom_threshold' );
 `
 
+= How to remove the `<noscript>` tag =
+
+You can use the `rocket_lazyload_noscript` filter to disable the addition of the `<noscript>` tag used for compatibility when JS is disabled.
+
+`add_filter( 'rocket_lazyload_noscript', '__return_false' );`
+
+= How to change the image placeholder for lazyloaded images =
+
+You can use the `rocket_lazyload_placeholder` to change the default placeholder for lazyloaded images.
+
+```
+function rocket_lazyload_custom_placeholder( $placeholder ) {
+    return 'default.jpg';
+}
+add_filter( 'rocket_lazyload_placeholder')
+```
+
+= How to change the HTML output before sending to the browser =
+
+You can use the `rocket_lazyload_html` filter to modify the HTML output generated after applying the lazyload and before sending it to the browser.
+
+= How to exclude YouTube videos from lazyload =
+
+You can use the `rocket_lazyload_exclude_youtube_thumbnail` filter to exclude patterns matching with the YouTube videos you don't want to lazyload.
+
+```
+function rocket_lazyload_exclude_youtube( $patterns ) {
+    $patterns[] = 'string_to_match';
+
+    return $patterns;
+}
+add_filter( 'rocket_lazyload_exclude_youtube_thumbnail', 'rocket_lazyload_exclude_youtube' );
+```
+
 = I use plugin X and my images don't show anymore =
 
 Some plugins are not compatible without lazy loading. Please open a support thread, and we will see how we can solve the issue by excluding lazy loading for this plugin.


### PR DESCRIPTION
# Description

Add missing documentation for filters from the lazyload common library

## Type of change

- [x] Chore


## Technical description

### Documentation

This PR updates the plugin documentation to cover additional LazyLoad filters exposed by the shared lazyload library, making it easier for users to customize behavior via WordPress hooks.

**Changes:**
- Added new FAQ/documentation entries for `rocket_lazyload_noscript`, `rocket_lazyload_placeholder`, `rocket_lazyload_html`, and `rocket_lazyload_exclude_youtube_thumbnail`.
- Reformatted existing code samples in `readme.md` to use fenced code blocks.
